### PR TITLE
tjc fix to humanPlay, return board if called with null move

### DIFF
--- a/Sevens/Game.cs
+++ b/Sevens/Game.cs
@@ -77,6 +77,8 @@ namespace Sevens
 
         public Board humanPlay(String indexOfCard)
         {
+            
+            if(indexOfCard==null) return board;
             Card cardToBePlayed = board.getQueue().getHumanPlayer().getCards()[(Convert.ToInt32(indexOfCard))];
 
             if (board.validMove(cardToBePlayed) == "y")


### PR DESCRIPTION
Added code to return board if humanPlay passed a null.

I believe humanPlay was being called with a null when pass button pressed.

